### PR TITLE
Make equipment optional

### DIFF
--- a/src/web_api_routes/slash_commands/pre_blast/mod.rs
+++ b/src/web_api_routes/slash_commands/pre_blast/mod.rs
@@ -84,7 +84,7 @@ fn create_pre_blast_modal(channel_id: &str, user_id: &str) -> ViewModal {
             pre_blast_post::pre_blast_action_ids::EQUIPMENT,
             equipment_list(),
             Some(ao_equipment),
-            false,
+            true,
         )
         .plain_input(
             "Other Equipment",

--- a/src/web_api_routes/slash_commands/pre_blast/pre_blast_post.rs
+++ b/src/web_api_routes/slash_commands/pre_blast/pre_blast_post.rs
@@ -34,6 +34,10 @@ impl PreBlastPost {
     }
 
     pub fn equipment_list(&self) -> String {
+        if self.equipment.is_empty() {
+            return String::from("None");
+        }
+
         self.equipment
             .iter()
             .map(|item| OptionElement::from(item).text.text)


### PR DESCRIPTION
Make equipment optional so that PAX can opt to list no equipment. If no equipment is selected in the preblast modal, show None in preblast post