### PR TITLE
feat: update coupon icon

### DIFF
--- a/src/app_state/equipment.rs
+++ b/src/app_state/equipment.rs
@@ -26,7 +26,7 @@ impl From<&AoEquipment> for OptionElement {
     fn from(value: &AoEquipment) -> Self {
         match value {
             AoEquipment::Coupons => {
-                OptionElement::new(&format!("{} 🧱", AoEquipment::Coupons), "coupon")
+                OptionElement::new_mkd(&format!("{} :coupon:", AoEquipment::Coupons), "coupon")
             }
             AoEquipment::Sandbag => {
                 OptionElement::new(&format!("{} 👝", AoEquipment::Sandbag), "sandbag")

--- a/src/slack_api/block_kit/block_elements.rs
+++ b/src/slack_api/block_kit/block_elements.rs
@@ -646,6 +646,15 @@ impl OptionElement {
             url: None,
         }
     }
+
+    pub fn new_mkd(text: &str, value: &str) -> Self {
+        OptionElement {
+            text: TextObject::new_markdown(text),
+            value: value.to_string(),
+            description: None,
+            url: None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
swap to use custom `coupon` icon for the coupon dropdown item