### PR TITLE
Add a no equipment type to Capitol

### DIFF
--- a/src/app_state/ao_data.rs
+++ b/src/app_state/ao_data.rs
@@ -51,12 +51,11 @@ pub enum AoType {
 impl Display for AoType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            AoType::Bootcamp => String::from("Bootcamp"),
+            AoType::Bootcamp | AoType::WildCard => String::from("Bootcamp"),
             AoType::HighIntensity => String::from("High Intensity"),
             AoType::Heavy => String::from("Ruck/Sandbag"),
             AoType::Running => String::from("Running"),
             AoType::Rucking => String::from("Ruck/Hike"),
-            AoType::WildCard => String::from("Wild Card"),
         };
         write!(f, "{}", str)
     }

--- a/src/app_state/ao_data.rs
+++ b/src/app_state/ao_data.rs
@@ -45,6 +45,7 @@ pub enum AoType {
     HighIntensity,
     Running,
     Rucking,
+    WildCard,
 }
 
 impl Display for AoType {
@@ -55,6 +56,7 @@ impl Display for AoType {
             AoType::Heavy => String::from("Ruck/Sandbag"),
             AoType::Running => String::from("Running"),
             AoType::Rucking => String::from("Ruck/Hike"),
+            AoType::WildCard => String::from("Wild Card"),
         };
         write!(f, "{}", str)
     }
@@ -72,7 +74,7 @@ impl AoType {
             AoType::Heavy => HashSet::from([AoEquipment::Ruck, AoEquipment::Sandbag]),
             AoType::Running => HashSet::from([AoEquipment::RunningShoes]),
             AoType::Rucking => HashSet::from([AoEquipment::Ruck, AoEquipment::Headlamp]),
-            AoType::NoEquipment => HashSet::from([]),
+            AoType::WildCard => HashSet::from([]),
         }
     }
 }
@@ -261,7 +263,7 @@ impl AO {
             AO::BernieFisher => AoType::Bootcamp,
             AO::WestCanyonElementary => AoType::Bootcamp,
             AO::EmmettCityPark => AoType::Bootcamp,
-            AO::Capitol => AoType::NoEquipment,
+            AO::Capitol => AoType::WildCard,
             AO::DR => AoType::Bootcamp,
             AO::Unknown(_) => AoType::Bootcamp,
         }

--- a/src/app_state/ao_data.rs
+++ b/src/app_state/ao_data.rs
@@ -72,6 +72,7 @@ impl AoType {
             AoType::Heavy => HashSet::from([AoEquipment::Ruck, AoEquipment::Sandbag]),
             AoType::Running => HashSet::from([AoEquipment::RunningShoes]),
             AoType::Rucking => HashSet::from([AoEquipment::Ruck, AoEquipment::Headlamp]),
+            AoType::NoEquipment => HashSet::from([]),
         }
     }
 }
@@ -260,7 +261,7 @@ impl AO {
             AO::BernieFisher => AoType::Bootcamp,
             AO::WestCanyonElementary => AoType::Bootcamp,
             AO::EmmettCityPark => AoType::Bootcamp,
-            AO::Capitol => AoType::Bootcamp,
+            AO::Capitol => AoType::NoEquipment,
             AO::DR => AoType::Bootcamp,
             AO::Unknown(_) => AoType::Bootcamp,
         }


### PR DESCRIPTION
The Capitol preblast dialog should init with no equipment